### PR TITLE
Add DirectorySearcher PageSize option to support > 1000 SPNs

### DIFF
--- a/DAFT/SQLServers.cs
+++ b/DAFT/SQLServers.cs
@@ -111,7 +111,8 @@ namespace DAFT
             {
                 SizeLimit = objectCountLimit,
                 Filter = filter,
-                SearchScope = SearchScope.Subtree
+                SearchScope = SearchScope.Subtree,
+                PageSize = 1000
             };
 
             try


### PR DESCRIPTION
The default DirectorySearcher() options will only pull 1000 SPNs from the domain.  This modification will allow all SPNs to be pulled on larger domains. 